### PR TITLE
[PF-32] - Predefined role ref

### DIFF
--- a/src/lib/import/import-utils.ts
+++ b/src/lib/import/import-utils.ts
@@ -182,7 +182,12 @@ export class ImportUtils {
         roleRef.logic.delegate = this.resolveLogicValue(this.tagValue(xmlRoleRefLogic, 'delegate'));
         roleRef.logic.perform = this.resolveLogicValue(this.tagValue(xmlRoleRefLogic, 'perform'));
         /* @deprecated - 'this.resolveLogicValue(this.tagValue(xmlRoleRefLogic, 'assigned'))' is deprecated and it and following line will be removed in future versions. */
-        roleRef.logic.assign = this.resolveLogicValue(this.tagValue(xmlRoleRefLogic, 'assigned')) || this.resolveLogicValue(this.tagValue(xmlRoleRefLogic, 'assign'))
+        const assigned = this.resolveLogicValue(this.tagValue(xmlRoleRefLogic, 'assigned'));
+        if (assigned !== undefined) {
+            roleRef.logic.assign = assigned;
+        } else {
+            roleRef.logic.assign = this.resolveLogicValue(this.tagValue(xmlRoleRefLogic, 'assign'));
+        }
         roleRef.logic.cancel = this.resolveLogicValue(this.tagValue(xmlRoleRefLogic, 'cancel'));
         roleRef.logic.view = this.resolveLogicValue(this.tagValue(xmlRoleRefLogic, 'view'));
     }

--- a/src/lib/model/petri-net.ts
+++ b/src/lib/model/petri-net.ts
@@ -147,7 +147,7 @@ export class PetriNet {
     }
 
     addRoleRef(roleRef: ProcessRoleRef) {
-        if (!this._roles.has(roleRef.id)) {
+        if (!this._roles.has(roleRef.id) && roleRef.id !== Role.DEFAULT && roleRef.id !== Role.ANONYMOUS) {
             throw new Error(`Referenced role with id ${roleRef.id} does not exist`);
         }
         if (this._roleRefs.has(roleRef.id)) {

--- a/src/lib/model/role/role.ts
+++ b/src/lib/model/role/role.ts
@@ -4,6 +4,9 @@ import {RoleEvent} from './role-event';
 import {RoleEventType} from './role-event-type.enum';
 
 export class Role extends EventSource<RoleEvent, RoleEventType> {
+    public static readonly ANONYMOUS = 'anonymous';
+    public static readonly DEFAULT = 'default';
+
     private _id: string;
     private _title: I18nString;
 

--- a/src/test/petriflow.spec.js
+++ b/src/test/petriflow.spec.js
@@ -50,7 +50,7 @@ const CASE_EVENTS_DELETE_PRE_LENGTH = 1;
 const CASE_EVENTS_DELETE_POST_LENGTH = 1;
 const ROLE_TITLE_VALUE = 'title';
 const MODEL_ROLES_LENGTH = 4;
-const MODEL_TRANSITIONS_LENGTH = 9;
+const MODEL_TRANSITIONS_LENGTH = 10;
 const MODEL_PLACES_LENGTH = 10;
 const MODEL_ARCS_LENGTH = 16;
 const MODEL_DATA_LENGTH = 20;
@@ -659,6 +659,11 @@ describe('Petriflow integration tests', () => {
         assertRoleRefLogic(transitionT9RoleRef1, false, false, true, true, true);
         const transitionT9RoleRef2 = transitionWithoutDataGroup.roleRefs.find(r => r.id === ROLE_2_ID);
         assertRoleRefLogic(transitionT9RoleRef2, undefined, undefined, false, true, undefined);
+        const transitionPredefinedRoles = model.getTransition('predefined_roles');
+        const transitionPredefinedRolesDefault = transitionPredefinedRoles.roleRefs.find(r => r.id === 'default');
+        assertRoleRefLogic(transitionPredefinedRolesDefault, false, false, true, true, undefined);
+        const transitionPredefinedRolesAnonymous = transitionPredefinedRoles.roleRefs.find(r => r.id === 'anonymous');
+        assertRoleRefLogic(transitionPredefinedRolesAnonymous, true, undefined, false, false, false);
         log('Model transitions correct');
 
         expect(model.getPlaces().length).toEqual(MODEL_PLACES_LENGTH);

--- a/src/test/petriflow.spec.js
+++ b/src/test/petriflow.spec.js
@@ -217,7 +217,7 @@ describe('Petriflow integration tests', () => {
         expect(processFunction.definition).toContain('}');
         log('Model functions correct');
 
-        expect(model.getRoleRefs().length).toEqual(3);
+        expect(model.getRoleRefs().length).toEqual(5);
         const roleRef1 = model.getRoleRef(ROLE_1_ID);
         expect(roleRef1.caseLogic.delete).toEqual(true);
         expect(roleRef1.caseLogic.create).toEqual(false);
@@ -230,6 +230,14 @@ describe('Petriflow integration tests', () => {
         expect(roleRef3.caseLogic.delete).toBeUndefined();
         expect(roleRef3.caseLogic.create).toEqual(false);
         expect(roleRef3.caseLogic.view).toEqual(true);
+        const roleRefAnonymous = model.getRoleRef('anonymous');
+        expect(roleRefAnonymous.caseLogic.create).toEqual(true);
+        expect(roleRefAnonymous.caseLogic.view).toEqual(false);
+        expect(roleRefAnonymous.caseLogic.delete).toEqual(undefined);
+        const roleRefDefault = model.getRoleRef('default');
+        expect(roleRefDefault.caseLogic.create).toEqual(undefined);
+        expect(roleRefDefault.caseLogic.view).toEqual(true);
+        expect(roleRefDefault.caseLogic.delete).toEqual(false);
         log('Model rol refs correct');
 
         expect(model.getUserRefs().length).toEqual(MODEL_USERREFS_LENGTH);

--- a/src/test/resources/petriflow_test.xml
+++ b/src/test/resources/petriflow_test.xml
@@ -919,6 +919,35 @@
             </logic>
         </dataRef>
     </transition>
+    <transition>
+        <id>predefined_roles</id>
+        <x>460</x>
+        <y>260</y>
+        <label></label>
+        <layout type="flow">
+            <cols>3</cols>
+            <offset>0</offset>
+            <fieldAlignment>bottom</fieldAlignment>
+        </layout>
+        <roleRef>
+            <id>default</id>
+            <logic>
+                <perform>false</perform>
+                <delegate>false</delegate>
+                <cancel>true</cancel>
+                <assigned>true</assigned>
+            </logic>
+        </roleRef>
+        <roleRef>
+            <id>anonymous</id>
+            <logic>
+                <perform>true</perform>
+                <view>false</view>
+                <cancel>false</cancel>
+                <assigned>false</assigned>
+            </logic>
+        </roleRef>
+    </transition>
     <!-- PLACES -->
     <place>
         <id>p1</id>

--- a/src/test/resources/petriflow_test.xml
+++ b/src/test/resources/petriflow_test.xml
@@ -10,6 +10,20 @@
     <caseName dynamic="true">${new Date() as String}</caseName>
     <!-- PROCESS ROLE REFS -->
     <roleRef>
+        <id>anonymous</id>
+        <caseLogic>
+            <create>true</create>
+            <view>false</view>
+        </caseLogic>
+    </roleRef>
+    <roleRef>
+        <id>default</id>
+        <caseLogic>
+            <delete>false</delete>
+            <view>true</view>
+        </caseLogic>
+    </roleRef>
+    <roleRef>
         <id>newRole_1</id>
         <caseLogic>
             <create>false</create>


### PR DESCRIPTION
- fix import of assign/assigned
- add anonymous and default roleRef to test net
- allow anonymous and default roleRef on PetriNet
- define anonymous and default role ids as static attributes of role.ts
- add anonymous and default processRoleRef to test net