### PR TITLE
[PF-79] Variables with no init values referenced in arcs will cause arcs not to load

### DIFF
--- a/src/lib/import/import-utils.ts
+++ b/src/lib/import/import-utils.ts
@@ -228,8 +228,16 @@ export class ImportUtils {
     }
 
     public attachReference(arc: Arc<NodeElement, NodeElement>, reference: Place | DataVariable): void {
-        const weight = reference instanceof Place ? reference.marking : parseInt(reference.init?.value ?? '' as string, 10);
-
+        let weight: number;
+        if (reference instanceof Place) {
+            weight = reference.marking;
+        } else {
+            if (!!reference.init && !!reference.init.value && /^[1-9]\d*$/.test(reference.init.value.trim())) {
+                weight = parseInt(reference.init.value.trim());
+            } else {
+                weight = 0;
+            }
+        }
         if (isNaN(weight)) {
             throw new Error('Not a number. Cannot change the value of arc weight.');
         }

--- a/src/lib/import/import-utils.ts
+++ b/src/lib/import/import-utils.ts
@@ -32,7 +32,7 @@ import {
     TransitionPermissionRef,
     Trigger,
     TriggerType,
-    XmlArcType
+    XmlArcType,
 } from '../model';
 
 export class ImportUtils {
@@ -232,7 +232,7 @@ export class ImportUtils {
         if (reference instanceof Place) {
             weight = reference.marking;
         } else {
-            if (!!reference.init && !!reference.init.value && /^[1-9]\d*$/.test(reference.init.value.trim())) {
+            if (reference.init?.value && ImportUtils.isInitValueNumber(reference.init)) {
                 weight = parseInt(reference.init.value.trim());
             } else {
                 weight = 0;
@@ -249,6 +249,29 @@ export class ImportUtils {
             arc.multiplicity = weight;
             arc.reference = reference.id;
         }
+    }
+
+    /**
+     * Determines whether the given value is an initial numeric value.
+     * This method checks if the provided `value` is defined, has a `value` property,
+     * and passes the `initValueNumberTest` logic.
+     *
+     * @param {I18nWithDynamic} [value] - The value to be checked.
+     * @return {boolean} Returns `true` if the value is an initial numeric value, otherwise `false`.
+     */
+    public static isInitValueNumber(value?: I18nWithDynamic): boolean {
+        return !!value && !!value.value && this.initValueNumberTest(value);
+    }
+
+    /**
+     * Validates whether the provided value in an I18nWithDynamic object is a valid positive number string.
+     *
+     * @param {I18nWithDynamic} [value] - The object containing the value to be tested.
+     * @return {boolean} Returns true if the value exists, is non-empty, and matches the regex pattern for a positive number; otherwise, returns false.
+     */
+    public static initValueNumberTest(value?: I18nWithDynamic): boolean {
+        if (!value || !value.value) return false;
+        return /^[1-9]\d*(\.0+)?$/.test(value.value.trim());
     }
 
     public parseTrigger(xmlTrigger: Element): Trigger {
@@ -373,7 +396,7 @@ export class ImportUtils {
     public parseEvent<T>(xmlEvent: Element, event: Event<T>): void {
         event.id = this.tagValue(xmlEvent, 'id');
         if (event.id === '') {
-            event.id = event.type + "_event_" + this.getNextEventId();
+            event.id = event.type + '_event_' + this.getNextEventId();
         }
         for (const actionsElement of Array.from(xmlEvent.getElementsByTagName('actions'))) {
             const actionsPhase = this.tagAttribute(actionsElement, 'phase') as EventPhase;


### PR DESCRIPTION
# Description

Fix loading arcs where referenced data had non integer init values

Fixes [PF-79]

## Dependencies

No new dependencies were introduced

### Third party dependencies

No new dependencies were introduced

### Blocking Pull requests

There are no dependencies on other PR

## How Has Been This Tested?

Manually tested in local dev env in running application

| Name                | Tested on |
|---------------------| --------- |
| OS                  |     Linux Mint 21      |
| Runtime             |      Node 20.13.1      |
| Dependency Manager  |    npm  10.8.0    |
| Framework version   |    Angular 13.3.1       |
| Run parameters      |           |
| Other configuration |           |


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked with @...
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
  - [x] Lint test
  - [x] Unit tests
  - [x] Integration tests
- [ ] I have checked my contribution with code analysis tools:
  - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_petriflow.js)
  - [ ] [Snyk](https://app.snyk.io/org/netgrif)
- [x] I have made corresponding changes to the documentation:
  - [x] Developer documentation
  - [x] User Guides
  - [x] Migration Guides


[PF-79]: https://netgrif.atlassian.net/browse/PF-79?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ