### PR TITLE
[PF-80] Global role support

### DIFF
--- a/src/lib/export/export.service.ts
+++ b/src/lib/export/export.service.ts
@@ -83,6 +83,7 @@ export class ExportService {
             const role = this.xmlConstructor.createElement('role');
             this._exportUtils.exportTag(role, 'id', item.id, true);
             this._exportUtils.exportI18nString(role, 'title', item.title, true);
+            this._exportUtils.exportTag(role, 'global', item.global ? 'true' : 'false');
             item.getEvents().forEach(event => {
                 this.exportEvent(role, event);
             });
@@ -98,7 +99,7 @@ export class ExportService {
 
     public exportEvent<T>(element: Element, event: Event<T>): void {
         if (event.isEmpty()) {
-            return
+            return;
         }
         let exportProcessEvent;
         if (event instanceof ProcessEvent) {
@@ -213,7 +214,7 @@ export class ExportService {
                 } else {
                     this._exportUtils.exportTag(exportData, 'encryption', 'true', false, [{
                         key: 'algorithm',
-                        value: data.encryption
+                        value: data.encryption,
                     }]);
                 }
             }
@@ -248,7 +249,7 @@ export class ExportService {
             translations.getI18ns().forEach(i18n => {
                 this._exportUtils.exportTag(i18ns, 'i18nString', i18n.value, false, [{
                     key: 'name',
-                    value: i18n.name ?? ''
+                    value: i18n.name ?? '',
                 }]);
             });
             doc.appendChild(i18ns);
@@ -353,7 +354,7 @@ export class ExportService {
             const props = this.xmlConstructor.createElement('properties');
             component.properties.forEach(prop => this._exportUtils.exportTag(props, 'property', prop.value, false, [{
                 key: 'key',
-                value: prop.key
+                value: prop.key,
             }]));
             const icons = this.xmlConstructor.createElement('option_icons');
             component.icons.forEach(icon => {
@@ -368,7 +369,7 @@ export class ExportService {
         } else {
             component.properties.forEach(prop => this._exportUtils.exportTag(comp, 'property', prop.value, false, [{
                 key: 'key',
-                value: prop.key
+                value: prop.key,
             }]));
         }
         element.appendChild(comp);

--- a/src/lib/import/import.service.ts
+++ b/src/lib/import/import.service.ts
@@ -149,6 +149,7 @@ export class ImportService {
             title = this.importUtils.parseI18n(xmlRole, 'name');
         }
         role.title = title;
+        role.global = this.importUtils.tagValue(xmlRole, 'global') === 'true';
         for (const xmlEvent of Array.from(xmlRole.getElementsByTagName('event'))) {
             const event = new RoleEvent(this.importUtils.tagAttribute(xmlEvent, 'type') as RoleEventType, '');
             event.message = this.importUtils.parseI18n(xmlEvent, 'message');

--- a/src/lib/model/role/role.ts
+++ b/src/lib/model/role/role.ts
@@ -9,11 +9,13 @@ export class Role extends EventSource<RoleEvent, RoleEventType> {
 
     private _id: string;
     private _title: I18nString;
+    private _global: boolean;
 
     constructor(id: string) {
         super();
         this._id = id;
         this._title = new I18nString('');
+        this._global = false;
     }
 
     get id(): string {
@@ -32,9 +34,18 @@ export class Role extends EventSource<RoleEvent, RoleEventType> {
         this._title = value;
     }
 
+    get global(): boolean {
+        return this._global;
+    }
+
+    set global(value: boolean) {
+        this._global = value;
+    }
+
     public clone(): Role {
         const cloned = new Role(this._id);
         cloned._title = this._title?.clone();
+        cloned._global = this._global;
         this.getEvents().forEach(event => cloned.addEvent(event.clone()));
         return cloned;
     }

--- a/src/test/petriflow.spec.js
+++ b/src/test/petriflow.spec.js
@@ -183,6 +183,7 @@ describe('Petriflow integration tests', () => {
         expect(role1.title).not.toBeUndefined();
         expect(role1.title.value).toEqual(ROLE_TITLE_VALUE);
         expect(role1.title.name).toEqual(ROLE_1_TITLE_NAME);
+        expect(role1.global).toEqual(false);
         expect(role1.getEvents().length).toEqual(2);
         const roleAssignEvent = role1.getEvent(RoleEventType.ASSIGN);
         expect(roleAssignEvent.id).toEqual('assign_role');
@@ -199,12 +200,15 @@ describe('Petriflow integration tests', () => {
         expect(role2.title).not.toBeUndefined();
         expect(role2.title.value).toEqual(ROLE_TITLE_VALUE);
         expect(role2.title.name).toEqual('role_2_title');
+        expect(role2.global).toEqual(true);
         expect(role3.title).not.toBeUndefined();
         expect(role3.title.value).toEqual(ROLE_TITLE_VALUE);
         expect(role3.title.name).toEqual('role_3_title');
+        expect(role3.global).toEqual(false);
         expect(role4.title).not.toBeUndefined();
         expect(role4.title.value).toEqual(ROLE_TITLE_VALUE);
         expect(role4.title.name).toEqual('role_4_title');
+        expect(role4.global).toEqual(false);
         log('Model roles correct');
 
         expect(model.functions).toBeDefined();

--- a/src/test/resources/petriflow_test.xml
+++ b/src/test/resources/petriflow_test.xml
@@ -240,6 +240,7 @@
     <role>
         <id>newRole_2</id>
         <title name="role_2_title">title</title>
+        <global>true</global>
     </role>
     <role>
         <id>newRole_3</id>


### PR DESCRIPTION
# Description

Add support for exporting and importing the "global" role flag.

Implements [PF-80]

## Dependencies

There are no dependencies on other PR.

## How Has Been This Tested?

Tested with Jest with petriflow.spec.js tests.

### Test Configuration

| Name                | Tested on |
|---------------------| --------- |
| OS                  |   Linux (ArchLinux)    |
| Runtime             |  Node 20        |
| Dependency Manager  |  npm         |
| Framework version   |         |
| Run parameters      |           |
| Other configuration |           |

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My changes have been checked with @...
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
  - [x] Lint test
  - [x] Unit tests
  - [ ] Integration tests
- [ ] I have checked my contribution with code analysis tools:
  - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_petriflow.js)
  - [ ] [Snyk](https://app.snyk.io/org/netgrif)
- [ ] I have made corresponding changes to the documentation:
  - [ ] Developer documentation
  - [ ] User Guides
  - [ ] Migration Guides


[PF-80]: https://netgrif.atlassian.net/browse/PF-80?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ